### PR TITLE
Allow curl to follow redirects

### DIFF
--- a/lib/central.rb
+++ b/lib/central.rb
@@ -362,7 +362,7 @@ def curl(url, path, content_length_check: false, verbose: false)
     return if file_size(path) == content_length
   end
   info 'Downloading', "#{url} → #{path}"
-  exit_code, output, = shell("curl -s -S \"#{url}\"",
+  exit_code, output, = shell("curl -L -s -S \"#{url}\"",
                              verbose: verbose, silent: true)
   unless exit_code.success?
     error output


### PR DESCRIPTION
Version 7.18.2 of curl added the switch `-L|--location`( https://manpages.org/curl) which is now being used (following max 20 redirects).

Resolves #1